### PR TITLE
feat: 회원가입 시, name 중복확인 처리

### DIFF
--- a/routes/api/register.js
+++ b/routes/api/register.js
@@ -20,6 +20,11 @@ router.post("/", async (req, res) => {
     if (user) {
       return res.status(400).json({ errors: [{ msg: "User already exists" }] });
     }
+    // name 중복 방지
+    let existing_name = await User.findOne({ name });
+    if (existing_name) {
+      return res.status(400).json({ errors: [{ msg: "User already exists" }] });
+    }
 		// (8) 존재하지 않는 email 인 경우, 새로운 사용자 객체 생성
     user = new User({
       name,


### PR DESCRIPTION
현재 회원가입 시 이메일만 중복되지 않도록 되어 있음.

DB 에 Collection을 생성할 때, "name" 기준으로 생성하므로, 회원가입 시 "name" 이 중복되지 않도록 처리해야함.